### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const uuid = require("node-uuid").v1,
+const uuid = require("uuid").v1,
 	path = require("path"),
 	config = require(path.join(__dirname, "..", "config.json")),
 	collectionRead = require(path.join(__dirname, "collectionRead.js")),

--- a/lib/newUser.js
+++ b/lib/newUser.js
@@ -2,7 +2,7 @@
 
 const deferred = require("tiny-defer"),
 	mpass = require("mpass"),
-	uuid = require("node-uuid").v1,
+	uuid = require("uuid").v1,
 	path = require("path"),
 	passwordCreate = require(path.join(__dirname, "passwordCreate.js")),
 	stores = require(path.join(__dirname, "stores.js"));

--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
     "haro-mongo": "~1.1.3",
     "jsonpatch": "~3.0.1",
     "mpass": "~1.0.2",
-    "node-uuid": "~1.4.7",
     "nodemailer": "~2.5.0",
     "redis": "~2.6.2",
     "request": "~2.74.0",
     "retsu": "~2.0.3",
     "tenso": "~4.0.3",
     "tiny-defer": "~1.0.4",
-    "tiny-lru": "~1.1.0"
+    "tiny-lru": "~1.1.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.